### PR TITLE
20 internal fields

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -116,6 +116,7 @@
         "monaco-yaml": "^5.3.1",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "react-error-boundary": "^6.0.0",
         "react-markdown": "^10.1.0",
         "react-resizable-panels": "^3.0.3",
         "react-window": "^1.8.11",

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -24,6 +24,7 @@
     "monaco-yaml": "^5.3.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-error-boundary": "^6.0.0",
     "react-markdown": "^10.1.0",
     "react-resizable-panels": "^3.0.3",
     "react-window": "^1.8.11"

--- a/packages/editor/src/components/Alert/index.tsx
+++ b/packages/editor/src/components/Alert/index.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import styled from '@emotion/styled';
 import { css } from '@emotion/react';
 import { Info, AlertTriangle, CheckCircle, AlertCircle } from 'lucide-react';
-import { Column } from '@hakit/components';
 
 type AlertSeverity = 'info' | 'warning' | 'success' | 'error';
 
@@ -11,6 +10,8 @@ interface AlertProps {
   severity?: AlertSeverity;
   title?: string;
   className?: string;
+  onClick?: () => void;
+  ref?: React.Ref<HTMLDivElement>;
 }
 
 const ICON_SIZE = 20;
@@ -118,7 +119,13 @@ const AlertIcon = styled.div<{ severity: AlertSeverity }>`
   ${props => getSeverityColorStyles(props.severity)}
 `;
 
-const AlertBody = styled(Column)`
+const AlertBody = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: flex-start;
+  flex-grow: 1;
+  gap: var(--space-1);
   min-width: 0;
   font-size: var(--font-size-sm);
   color: var(--color-text-primary);
@@ -215,12 +222,12 @@ const AlertMessage = styled.div<{ severity: AlertSeverity }>`
   }
 `;
 
-export function Alert({ children, severity = 'info', title, className }: AlertProps) {
+export function Alert({ children, severity = 'info', title, className, onClick, ref }: AlertProps) {
   return (
-    <AlertContainer severity={severity} className={className}>
+    <AlertContainer severity={severity} className={className} onClick={onClick} ref={ref}>
       <AlertContent>
         <AlertIcon severity={severity}>{getSeverityIcon(severity)}</AlertIcon>
-        <AlertBody alignItems='flex-start' justifyContent='flex-start' gap='var(--space-1)'>
+        <AlertBody>
           {title && <AlertTitle severity={severity}>{title}</AlertTitle>}
           {children && <AlertMessage severity={severity}>{children}</AlertMessage>}
         </AlertBody>

--- a/packages/editor/src/features/dashboard/Editor/ErrorBoundary/index.tsx
+++ b/packages/editor/src/features/dashboard/Editor/ErrorBoundary/index.tsx
@@ -1,57 +1,41 @@
-import type { DefaultComponentProps } from '@measured/puck';
-import type { CustomComponentConfig } from '@typings/puck';
-import { Component, type ReactNode } from 'react';
+import { type ReactNode } from 'react';
 import { Alert } from '@components/Alert';
+import { ErrorBoundary, ErrorBoundaryProps } from 'react-error-boundary';
+import { useGlobalStore } from '@hooks/useGlobalStore';
 
-export class ComponentRenderErrorBoundary<P extends DefaultComponentProps> extends Component<
-  {
-    children: ReactNode;
-    componentConfig?: CustomComponentConfig<P>;
-    dragRef?: ((element: Element | null) => void) | null;
+interface Fallback {
+  prefix: string;
+  ref?: ((element: Element | null) => void) | null;
+}
+
+export const fallback = ({ prefix, ref }: Fallback): ErrorBoundaryProps => ({
+  fallbackRender({ error, resetErrorBoundary }) {
+    return (
+      <Alert ref={ref} className={`error-boundary-alert`} title={prefix} severity='error' onClick={() => resetErrorBoundary()}>
+        {error.message ? error.message : 'An error occurred while rendering this component'}
+      </Alert>
+    );
   },
-  { hasError: boolean; error?: Error }
-> {
-  constructor(props: {
-    children: ReactNode;
-    componentConfig?: CustomComponentConfig<P>;
-    dragRef?: ((element: Element | null) => void) | null;
-  }) {
-    super(props);
-    this.state = { hasError: false };
-  }
+});
 
-  static getDerivedStateFromError(error: Error) {
-    return { hasError: true, error };
-  }
+type ComponentRenderErrorBoundaryProps = {
+  children: ReactNode;
+  ref?: ((element: Element | null) => void) | null;
+} & Fallback;
 
-  componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
-    console.error('HAKIT: Component render error:', error, errorInfo);
-    console.error('HAKIT: Component type:', this.props.componentConfig?.label);
-  }
-
-  componentDidUpdate(prevProps: { children: ReactNode; componentConfig?: CustomComponentConfig<P> }) {
-    // Reset error state if the component type changes (new component being rendered)
-    if (prevProps.componentConfig?.label !== this.props.componentConfig?.label && this.state.hasError) {
-      this.setState({ hasError: false, error: undefined });
-    }
-  }
-
-  render() {
-    if (this.state.hasError) {
-      return (
-        <div ref={this.props.dragRef} style={{ position: 'relative', width: '100%' }}>
-          <Alert
-            title={`Component Render Error${this.props.componentConfig?.label ? ` (${this.props.componentConfig?.label})` : ''}`}
-            severity='error'
-          >
-            <p style={{ margin: '0 0 var(--space-2) 0' }}>
-              {this.state.error?.message || 'An error occurred while rendering this component'}
-            </p>
-          </Alert>
-        </div>
-      );
-    }
-
-    return this.props.children;
-  }
+export function ComponentRenderErrorBoundary({ children, prefix, ref }: ComponentRenderErrorBoundaryProps) {
+  return (
+    <ErrorBoundary
+      {...fallback({ prefix, ref })}
+      onError={(error, errorInfo) => {
+        console.error('HAKIT: Error rendering component:', prefix, error, errorInfo);
+        useGlobalStore.getState().setComponentError({
+          title: prefix,
+          message: error.message ? error.message : 'An error occurred while rendering this component',
+        });
+      }}
+    >
+      {children}
+    </ErrorBoundary>
+  );
 }

--- a/packages/editor/src/features/dashboard/PuckDynamicConfiguration/index.tsx
+++ b/packages/editor/src/features/dashboard/PuckDynamicConfiguration/index.tsx
@@ -1,4 +1,4 @@
-import { Config, DefaultComponentProps, Slot } from '@measured/puck';
+import { Config, DefaultComponentProps } from '@measured/puck';
 import { registerRemotes, loadRemote } from '@module-federation/enhanced/runtime';
 import { type UserOptions } from '@module-federation/runtime-core';
 import {
@@ -15,14 +15,6 @@ import { createRootComponent } from '@helpers/editor/createRootComponent';
 interface ComponentModule {
   config: CustomComponentConfig<DefaultComponentProps>;
 }
-
-export type InternalRootData = {
-  _styleOverrides?: {
-    style: string;
-  };
-  content: Slot;
-  _remoteRepositoryId?: string; // Optional remote name for tracking
-};
 
 export type CustomRootConfigWithRemote<P extends DefaultComponentProps = DefaultComponentProps> = CustomComponentConfig<P> & {
   _remoteRepositoryId: string; // remote id for tracking
@@ -167,7 +159,6 @@ export async function getPuckConfiguration(data: ComponentFactoryData) {
   const config: CustomConfigWithDefinition<DefaultComponentProps> = {
     components,
     categories,
-    // @ts-expect-error - this is fine, it just has additional properties that puck doesn't care about
     root: rootConfig,
   };
 

--- a/packages/editor/src/helpers/editor/createCustomField/CustomAutoField/index.tsx
+++ b/packages/editor/src/helpers/editor/createCustomField/CustomAutoField/index.tsx
@@ -44,6 +44,19 @@ export function CustomAutoField<Props extends DefaultComponentProps>({ field, na
     return <input type='hidden' value={_value} />;
   }
 
+  if (field.type === 'custom') {
+    return field.render({
+      field: {
+        type: 'custom',
+        render: field.render,
+      },
+      name,
+      id: field.id ?? name,
+      value: _value,
+      onChange: _onChange,
+    });
+  }
+
   if (field.type === 'imageUpload') {
     return <ImageUpload id={field.id ?? name} value={typeof _value === 'string' ? _value : ''} onChange={_onChange} />;
   }
@@ -254,6 +267,6 @@ export function CustomAutoField<Props extends DefaultComponentProps>({ field, na
       </div>
     );
   }
-
-  return <StyledAlert severity='error'>Unsupported field type: &quot;{field.type}&quot;</StyledAlert>;
+  // Helper function for exhaustive type checking
+  return <StyledAlert severity='error'>Unsupported field type: &quot;{(field as { type?: string }).type ?? 'unknown'}&quot;</StyledAlert>;
 }

--- a/packages/editor/src/helpers/editor/createCustomField/index.tsx
+++ b/packages/editor/src/helpers/editor/createCustomField/index.tsx
@@ -179,12 +179,15 @@ function CustomFieldComponentInner<Props extends DefaultComponentProps>({
     );
   }
 
-  if (!isVisible) {
-    return null;
-  }
+  // if (!isVisible) {
+  //   return null;
+  // }
 
   return (
     <Fieldset
+      style={{
+        display: isVisible ? 'block' : 'none',
+      }}
       id={id}
       className={`hakit-field ${field.className ?? ''} ${field.type ? `field-${field.type}` : ''} ${field.collapseOptions ? 'collapsible' : ''} ${
         breakpointMode && field.responsiveMode ? 'bp-mode-enabled' : ''

--- a/packages/editor/src/helpers/editor/createPuckComponent/createComponent.test.tsx
+++ b/packages/editor/src/helpers/editor/createPuckComponent/createComponent.test.tsx
@@ -56,19 +56,9 @@ await moduleMocker.mock('leaflet', () => ({
 }));
 
 // Mock functions for testing
-const mockGetDefaultPropsFromFields = mock(() => Promise.resolve({}));
-const mockTransformFields = mock((fields: unknown) => fields);
 const mockUseActiveBreakpoint = mock(() => 'desktop');
 const mockUseGlobalStore = mock(() => ({ dashboardWithoutData: { id: 'test-dashboard' } }));
 const mockUsePuckIframeElements = mock(() => ({ iframe: null, document: null }));
-
-await moduleMocker.mock('@helpers/editor/pageData/getDefaultPropsFromFields', () => ({
-  getDefaultPropsFromFields: mockGetDefaultPropsFromFields,
-}));
-
-await moduleMocker.mock('@helpers/editor/pageData/transformFields', () => ({
-  transformFields: mockTransformFields,
-}));
 
 await moduleMocker.mock('@hooks/useActiveBreakpoint', () => ({
   useActiveBreakpoint: mockUseActiveBreakpoint,
@@ -111,8 +101,6 @@ function SimpleComponent({ text, count }: SimpleProps) {
 describe('createComponent', () => {
   beforeEach(() => {
     // Reset all mocks
-    mockGetDefaultPropsFromFields.mockClear();
-    mockTransformFields.mockClear();
     mockUseActiveBreakpoint.mockClear();
     mockUseGlobalStore.mockClear();
     mockUsePuckIframeElements.mockClear();
@@ -161,14 +149,14 @@ describe('createComponent', () => {
 
     const data = createMockComponentFactoryData();
     const componentFactory = createComponent(config);
-    await componentFactory(data);
-
-    expect(mockGetDefaultPropsFromFields).toHaveBeenCalledTimes(1);
-    expect(mockGetDefaultPropsFromFields).toHaveBeenCalledWith(
-      config.fields,
+    const result = await componentFactory(data);
+    expect(result.defaultProps).toEqual(
       expect.objectContaining({
-        entities: expect.any(Object),
-        services: expect.any(Object),
+        text: 'hello',
+        count: 0,
+        _activeBreakpoint: 'xlg',
+        // css may be undefined initially
+        styles: expect.objectContaining({ css: undefined }),
       })
     );
   });
@@ -201,25 +189,25 @@ describe('createComponent', () => {
 
     const data = createMockComponentFactoryData();
     const componentFactory = createComponent(config);
-    await componentFactory(data);
+    const result = await componentFactory(data);
 
-    expect(mockTransformFields).toHaveBeenCalledTimes(1);
+    const transformedFields = result.fields as Record<string, any>;
+    expect(transformedFields).toHaveProperty('text');
+    expect(transformedFields).toHaveProperty('_activeBreakpoint');
+    expect(transformedFields).toHaveProperty('styles');
 
-    // Check the actual call arguments
-    const actualCallArg = mockTransformFields.mock.calls[0][0] as Record<string, unknown>;
-    expect(actualCallArg).toHaveProperty('text');
-    expect(actualCallArg).toHaveProperty('_styleOverrides');
-    expect(actualCallArg).toHaveProperty('_activeBreakpoint');
+    // Verify transformed structure
+    expect(transformedFields.text.type).toBe('custom');
+    expect(transformedFields.text._field.type).toBe('text');
 
-    // Verify the _activeBreakpoint field has the correct structure
-    const activeBreakpointField = actualCallArg._activeBreakpoint as Record<string, unknown>;
+    const activeBreakpointField = transformedFields._activeBreakpoint as Record<string, unknown>;
     expect(activeBreakpointField.type).toBe('custom');
     expect(typeof activeBreakpointField.render).toBe('function');
 
-    // Verify the _styleOverrides field has the correct structure
-    const styleOverridesField = actualCallArg._styleOverrides as Record<string, unknown>;
-    expect(styleOverridesField.type).toBe('object');
-    expect(styleOverridesField.label).toBe('Style Overrides');
+    const stylesField = transformedFields.styles as Record<string, any>;
+    expect(stylesField.type).toBe('custom');
+    expect(stylesField._field.type).toBe('object');
+    expect(stylesField._field.label).toBe('Style Overrides');
   });
 
   test('should handle empty fields correctly', async () => {
@@ -231,22 +219,20 @@ describe('createComponent', () => {
 
     const data = createMockComponentFactoryData();
     const componentFactory = createComponent(config);
-    await componentFactory(data);
+    const result = await componentFactory(data);
 
-    // Even with empty fields, the _activeBreakpoint and _styleOverrides fields should be added
-    const actualCallArg = mockTransformFields.mock.calls[0][0] as Record<string, unknown>;
-    expect(actualCallArg).toHaveProperty('_styleOverrides');
-    expect(actualCallArg).toHaveProperty('_activeBreakpoint');
+    const transformedFields = result.fields as Record<string, any>;
+    expect(transformedFields).toHaveProperty('_activeBreakpoint');
+    expect(transformedFields).toHaveProperty('styles');
 
-    // Verify the _activeBreakpoint field has the correct structure
-    const activeBreakpointField = actualCallArg._activeBreakpoint as Record<string, unknown>;
+    const activeBreakpointField = transformedFields._activeBreakpoint as Record<string, unknown>;
     expect(activeBreakpointField.type).toBe('custom');
     expect(typeof activeBreakpointField.render).toBe('function');
 
-    // Verify the _styleOverrides field has the correct structure
-    const styleOverridesField = actualCallArg._styleOverrides as Record<string, unknown>;
-    expect(styleOverridesField.type).toBe('object');
-    expect(styleOverridesField.label).toBe('Style Overrides');
+    const stylesField = transformedFields.styles as Record<string, any>;
+    expect(stylesField.type).toBe('custom');
+    expect(stylesField._field.type).toBe('object');
+    expect(stylesField._field.label).toBe('Style Overrides');
   });
 
   test('should preserve original config properties', async () => {
@@ -271,7 +257,6 @@ describe('createComponent', () => {
 
   test('should set default props from field defaults', async () => {
     const expectedDefaults = { text: 'default text', count: 42 };
-    mockGetDefaultPropsFromFields.mockResolvedValueOnce(expectedDefaults);
 
     const config: CustomComponentConfig<SimpleProps> = {
       label: 'Test Component',
@@ -285,8 +270,13 @@ describe('createComponent', () => {
     const data = createMockComponentFactoryData();
     const componentFactory = createComponent(config);
     const result = await componentFactory(data);
-
-    expect(result.defaultProps).toEqual(expectedDefaults);
+    expect(result.defaultProps).toEqual(
+      expect.objectContaining({
+        ...expectedDefaults,
+        _activeBreakpoint: 'xlg',
+        styles: expect.objectContaining({ css: undefined }),
+      })
+    );
   });
 
   test('should create breakpoint field with correct behavior', async () => {
@@ -300,16 +290,12 @@ describe('createComponent', () => {
 
     const data = createMockComponentFactoryData();
     const componentFactory = createComponent(config);
-    await componentFactory(data);
+    const result = await componentFactory(data);
 
-    // Verify the breakpoint field was added to transformed fields
-    const transformedFieldsCall = mockTransformFields.mock.calls[0][0] as Record<string, unknown>;
-    expect(transformedFieldsCall._activeBreakpoint).toBeDefined();
-    expect((transformedFieldsCall._activeBreakpoint as { type: string }).type).toBe('custom');
-
-    // Also verify _styleOverrides was added
-    expect(transformedFieldsCall._styleOverrides).toBeDefined();
-    expect((transformedFieldsCall._styleOverrides as { type: string }).type).toBe('object');
+    const transformedFields = result.fields as Record<string, any>;
+    expect(transformedFields._activeBreakpoint).toBeDefined();
+    expect((transformedFields._activeBreakpoint as { type: string }).type).toBe('custom');
+    expect(transformedFields.styles).toBeDefined();
   });
 
   test('should maintain consistent behavior across multiple calls', async () => {
@@ -373,8 +359,6 @@ describe('createComponent', () => {
     // Verify all required functions were called
     expect(data.getAllEntities).toHaveBeenCalled();
     expect(data.getAllServices).toHaveBeenCalled();
-    expect(mockGetDefaultPropsFromFields).toHaveBeenCalled();
-    expect(mockTransformFields).toHaveBeenCalled();
   });
 
   test('should handle styles function correctly', async () => {

--- a/packages/editor/src/helpers/editor/createPuckComponent/index.tsx
+++ b/packages/editor/src/helpers/editor/createPuckComponent/index.tsx
@@ -1,32 +1,58 @@
-import { AvailableQueries } from '@hakit/components';
 import { getDefaultPropsFromFields } from '@helpers/editor/pageData/getDefaultPropsFromFields';
 import { transformFields } from '@helpers/editor/pageData/transformFields';
-import { useActiveBreakpoint } from '@hooks/useActiveBreakpoint';
 import { useGlobalStore } from '@hooks/useGlobalStore';
 import { usePuckIframeElements } from '@hooks/usePuckIframeElements';
-import { DefaultComponentProps } from '@measured/puck';
-import { AdditionalRenderProps, ComponentFactoryData, CustomComponentConfig, CustomComponentConfigWithDefinition } from '@typings/puck';
-import { useEffect, useMemo } from 'react';
+import {
+  AdditionalRenderProps,
+  ComponentFactoryData,
+  CustomComponentConfig,
+  CustomComponentConfigWithDefinition,
+  RenderProps,
+} from '@typings/puck';
+import { useMemo } from 'react';
 import { attachDragRefToElement } from './attachDragRefToElement';
 import { useEmotionCss, type StyleStrings } from './generateEmotionCss';
-import { FieldConfiguration, CustomFieldsWithDefinition } from '@typings/fields';
+import { FieldConfiguration, InternalComponentFields } from '@typings/fields';
 import { ComponentRenderErrorBoundary } from '@features/dashboard/Editor/ErrorBoundary';
+import { internalComponentFields, internalRootComponentFields } from '../internalFields';
 
 /**
  * Takes an existing CustomComponentConfig and returns a new config
  * whose render method is wrapped so we can pass `activeBreakpoint`.
  */
 
-type CustomComponentConfigurationWithDefinitionAndPuck<P extends DefaultComponentProps> = CustomComponentConfigWithDefinition<P> & {
+type CustomComponentConfigurationWithDefinitionAndPuck<P extends object> = CustomComponentConfigWithDefinition<P> & {
   defaultProps: P;
   inline: boolean;
 };
 
-export function createComponent<P extends DefaultComponentProps>(
-  config: CustomComponentConfig<P>
-): (data: ComponentFactoryData) => Promise<CustomComponentConfigurationWithDefinitionAndPuck<P>> {
+// Function overloads for better type safety
+// export function createComponent<P extends object>(
+//   config: CustomComponentConfig<P>,
+//   isRootComponent: true
+// ): (data: ComponentFactoryData) => Promise<CustomComponentConfigurationWithDefinitionAndPuck<P & InternalRootComponentFields>>;
+// export function createComponent<P extends object>(
+//   config: CustomComponentConfig<P>,
+//   isRootComponent?: false
+// ): (data: ComponentFactoryData) => Promise<CustomComponentConfigurationWithDefinitionAndPuck<P & InternalComponentFields>>;
+export function createComponent<P extends object>(
+  config: CustomComponentConfig<P>,
+  isRootComponent = false
+): (data: ComponentFactoryData) => Promise<
+  CustomComponentConfigurationWithDefinitionAndPuck<P & InternalComponentFields>
+  // | CustomComponentConfigurationWithDefinitionAndPuck<P & InternalRootComponentFields>
+> {
   return async function (data: ComponentFactoryData) {
-    const fields = config.fields;
+    // Merge the field configurations - type assertion is necessary due to mapped type limitations
+    const fields = isRootComponent
+      ? ({
+          ...config.fields,
+          ...internalRootComponentFields,
+        } as FieldConfiguration<P & InternalComponentFields>)
+      : ({
+          ...config.fields,
+          ...internalComponentFields,
+        } as FieldConfiguration<P & InternalComponentFields>);
     const entities = data.getAllEntities();
     const services = await data.getAllServices();
 
@@ -35,132 +61,89 @@ export function createComponent<P extends DefaultComponentProps>(
       entities,
       services,
     });
-    const isRootComponent = config.label === 'Root';
-    const styleField: FieldConfiguration<{
-      _styleOverrides: {
-        style: string;
-      };
-    }> = {
-      _styleOverrides: {
-        type: 'object',
-        label: isRootComponent ? 'Global styles' : 'Style Overrides',
-        collapseOptions: {
-          startExpanded: false,
-        },
-        description: isRootComponent
-          ? 'Provide global CSS styles for the entire dashboard'
-          : 'Provide css updates to override the default styles of this component',
-        objectFields: {
-          style: {
-            type: 'code',
-            language: 'css',
-            label: 'CSS Styles',
-            description: isRootComponent
-              ? 'Provide global CSS styles for the entire dashboard'
-              : 'Provide css updates to override the default styles of this component',
-            default: '',
-          },
-        },
-      },
-    };
-    const actualField = styleField._styleOverrides;
-    // @ts-expect-error - we know it doesn't exist, we're adding it intentionally
-    fields._styleOverrides = actualField;
     // convert the input field structure to custom field definitions
     const transformedFields = transformFields(fields, false);
-    // include a local breakpoint field that we can use automatically to determine the current breakpoint
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const breakpointField: CustomFieldsWithDefinition<any, keyof AvailableQueries> = {
-      type: 'custom',
-      _field: {
-        type: 'text',
-        default: 'xlg',
-        responsiveMode: false,
-        label: 'Active Breakpoint',
-        description: 'The current active breakpoint for this component',
-      },
-      render({ onChange }) {
-        // eslint-disable-next-line react-hooks/rules-of-hooks
-        const breakpoint = useActiveBreakpoint();
-        // eslint-disable-next-line react-hooks/rules-of-hooks
-        useEffect(() => {
-          onChange(breakpoint);
-        }, [onChange, breakpoint]);
-        return <input name='_activeBreakpoint' type='hidden' value={breakpoint} />;
-      },
-    };
-    // attach internal breakpoint field
-    // @ts-expect-error - we know it doesn't exist, we're adding it intentionally
-    transformedFields._activeBreakpoint = breakpointField;
 
     // this is the config that will be used for puck
-    const updatedConfig: CustomComponentConfigurationWithDefinitionAndPuck<P> = {
+    return {
       ...config,
       // replace the default props
       defaultProps,
       // All components are inline by default for automatic dragRef attachment
       inline: true,
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      render({ _styleOverrides, editMode = false, puck, id, children, ...props }) {
-        // eslint-disable-next-line react-hooks/rules-of-hooks
-        const editorElements = usePuckIframeElements();
-        // eslint-disable-next-line react-hooks/rules-of-hooks
-        const dashboard = useGlobalStore(state => state.dashboardWithoutData);
-        // Extract the correct type for renderProps from the config's render function
-        // eslint-disable-next-line react-hooks/rules-of-hooks
-        const fullProps = useMemo(() => {
-          const renderProps: AdditionalRenderProps = {
-            _id: id,
-            _editMode: editMode ?? puck.isEditing, // Ensure editMode is always defined
-            _activeBreakpoint: props._activeBreakpoint as keyof AvailableQueries,
-            _editor: editorElements,
-            _dashboard: dashboard,
-          };
-
-          return {
-            ...props,
-            ...renderProps,
-          } as Parameters<typeof config.render>[0];
-        }, [props, id, puck, editMode, editorElements, dashboard]);
-
-        // Generate style strings for emotion CSS processing in iframe context
-        // eslint-disable-next-line react-hooks/rules-of-hooks
-        const styleStrings = useMemo(() => {
-          try {
-            const componentStyles = config.styles ? config.styles(fullProps) : '';
-            const overrideStyles = _styleOverrides?.style ?? '';
-            return {
-              componentStyles,
-              overrideStyles,
-            } satisfies StyleStrings;
-          } catch (error) {
-            console.error('HAKIT: Error generating styles for component:', config.label, error);
-            return {
-              componentStyles: '',
-              overrideStyles: '',
-            } satisfies StyleStrings;
-          }
-        }, [fullProps, _styleOverrides]);
-
-        // Generate emotion CSS in iframe context where correct cache is active
-        // eslint-disable-next-line react-hooks/rules-of-hooks
-        const emotionCss = useEmotionCss(styleStrings);
-
-        // Wrap the config.render call in an error boundary to catch rendering errors
+      // this render function is ONLY used for components, rootComponents redefine the render function
+      // which is why here we only provide InternalComponentFields
+      render(renderProps: RenderProps<P & InternalComponentFields>) {
         return (
-          <ComponentRenderErrorBoundary<P> componentConfig={config} dragRef={puck?.dragRef}>
-            {(() => {
-              const renderedElement = config.render(fullProps);
-              // Automatically attach dragRef to the top-level element with emotion CSS
-              return attachDragRefToElement(renderedElement, puck?.dragRef, config.label, emotionCss);
-            })()}
+          <ComponentRenderErrorBoundary prefix={config.label} ref={renderProps?.puck?.dragRef}>
+            <Render {...renderProps} internalComponentConfig={config} />
           </ComponentRenderErrorBoundary>
         );
       },
       // This is just to make puck happy on the consumer side, Fields aren't actually the correct type here
       fields: transformedFields,
     };
-
-    return updatedConfig;
   };
+}
+
+function Render<P extends object>(
+  renderProps: RenderProps<P & InternalComponentFields> & {
+    internalComponentConfig: CustomComponentConfig<P>;
+  }
+) {
+  const { styles, editMode = false, puck, id, internalComponentConfig: config, ...props } = renderProps;
+  const editorElements = usePuckIframeElements();
+  const dashboard = useGlobalStore(state => state.dashboardWithoutData);
+  // Extract the correct type for renderProps from the config's render function
+  // eslint-disable-next-ine react-hooks/rules-of-hooks
+  const fullProps = useMemo(() => {
+    const renderProps: AdditionalRenderProps = {
+      _id: id,
+      _editMode: editMode ?? puck.isEditing, // Ensure editMode is always defined
+      // _activeBreakpoint: props._activeBreakpoint as keyof AvailableQueries,
+      _editor: editorElements,
+      _dashboard: dashboard,
+    };
+
+    const obj = {
+      ...props,
+      ...renderProps,
+    } as P & InternalComponentFields & AdditionalRenderProps;
+    return obj;
+  }, [props, id, puck, editMode, editorElements, dashboard]);
+
+  // Generate style strings for emotion CSS processing in iframe context
+  const styleStrings = useMemo(() => {
+    try {
+      const componentStyles = config.styles ? config.styles(fullProps) : '';
+      const overrideStyles = styles?.css ?? '';
+      return {
+        componentStyles,
+        overrideStyles,
+      } satisfies StyleStrings;
+    } catch (error) {
+      console.error('HAKIT: Error generating styles for component:', config.label, error);
+      return {
+        componentStyles: '',
+        overrideStyles: '',
+      } satisfies StyleStrings;
+    }
+  }, [fullProps, styles, config]);
+
+  // Generate emotion CSS in iframe context where correct cache is active
+  const emotionCss = useEmotionCss(styleStrings);
+
+  // Generate the rendered element outside the error boundary to ensure proper error catching
+  const renderedElement = useMemo(() => {
+    try {
+      // @ts-expect-error - this is okay, we can't type at this level
+      return config.render(fullProps);
+    } catch (error) {
+      console.error('HAKIT: Error in config.render for component:', config.label, error);
+      throw error; // Re-throw to be caught by error boundary
+    }
+  }, [fullProps, config]);
+
+  // Wrap the rendered element with error boundary to catch rendering errors
+  return attachDragRefToElement(renderedElement, puck?.dragRef, config.label, emotionCss);
 }

--- a/packages/editor/src/helpers/editor/createRootComponent/index.tsx
+++ b/packages/editor/src/helpers/editor/createRootComponent/index.tsx
@@ -4,22 +4,19 @@ import {
   CustomRootConfigWithDefinition,
   IgnorePuckConfigurableOptions,
   RenderProps,
+  InternalRootData,
 } from '@typings/puck';
-import { CustomRootConfigWithRemote, InternalRootData } from '../../../features/dashboard/PuckDynamicConfiguration';
+import { Fragment } from 'react';
+import { CustomRootConfigWithRemote } from '../../../features/dashboard/PuckDynamicConfiguration';
 import { createComponent } from '@helpers/editor/createPuckComponent';
 import { defaultRootConfig, DefaultRootProps } from '@helpers/editor/createRootComponent/defaultRoot';
-import { DefaultComponentProps, Slot, WithChildren } from '@measured/puck';
+import { DefaultComponentProps } from '@measured/puck';
 import { css, Global } from '@emotion/react';
-import { CustomFields, FieldConfiguration, FieldConfigurationWithDefinition } from '@typings/fields';
+import { CustomFields, InternalRootComponentFields } from '@typings/fields';
 import { useGlobalStore } from '@hooks/useGlobalStore';
 import { usePuckIframeElements } from '@hooks/usePuckIframeElements';
-import { AvailableQueries } from '@hakit/components';
 import { attachRepositoryReference } from '../pageData/transformFields';
 import { ComponentRenderErrorBoundary } from '@features/dashboard/Editor/ErrorBoundary';
-
-type InternalRootConfigFields = {
-  content: Slot;
-};
 
 export async function createRootComponent<P extends DefaultComponentProps>(
   rootConfigs: CustomRootConfigWithRemote<P>[],
@@ -75,121 +72,124 @@ export async function createRootComponent<P extends DefaultComponentProps>(
   /// now we have the merged structure, we can now create the dynamic configurations
 
   // create the puck definitions
-  const componentFactory = await createComponent<P>({
-    // Merge other properties from base config (excluding render and fields)
-    ...baseConfig,
-    // Set the merged fields
-    // @ts-expect-error - this will never match the root data as it's dynamically created above
-    fields: mergedFields,
-    defaultProps: {},
-    render() {
-      return <></>;
+  const componentFactory = await createComponent<P>(
+    {
+      // Merge other properties from base config (excluding render and fields)
+      ...baseConfig,
+      // Set the merged fields
+      // @ts-expect-error - this will never match the root data as it's dynamically created above
+      fields: mergedFields,
+      defaultProps: {},
+      render() {
+        return <></>;
+      },
     },
-  });
+    true
+  );
   // use our component factory to convert out component structure to a puck component
   const updatedRootConfig = await componentFactory(data);
 
-  function getPropsForRoot<P extends DefaultComponentProps>(
-    rootConfig: CustomRootConfigWithRemote<P>,
-    props: Record<string, unknown>,
-    additionalProps: AdditionalRenderProps
-  ) {
-    // Create a new props object without any remote keys
-    // trim off any remote objects that do not match the current rootConfig
-    const baseProps = Object.fromEntries(Object.entries(props).filter(([key]) => !remoteKeys.has(key)));
-    // Get the current remote's props and spread them at the top level
-    const currentRemoteProps = props[rootConfig._remoteRepositoryId] || {};
-    // Combine base props with current remote's props and style overrides
-    const propsForThisRoot = {
-      // ...props, // Start with all original props to ensure required props are present
-      ...baseProps, // Override with filtered base props (without other remotes)
-      ...(typeof currentRemoteProps === 'object' && currentRemoteProps !== null ? currentRemoteProps : {}),
-      ...additionalProps,
-    };
-    return propsForThisRoot as RenderProps<WithChildren<InternalRootData>>;
-  }
-  // We know that content is always a slot field, so we can safely construct this
-  const fields: Omit<FieldConfigurationWithDefinition<InternalRootData, true>, 'content'> = {
-    ...updatedRootConfig.fields,
-  };
-
-  const internalFields: FieldConfiguration<InternalRootConfigFields> = {
-    content: {
-      type: 'slot',
-    },
-  };
-  const finalRootConfig: Omit<CustomRootConfigWithDefinition<InternalRootData>, IgnorePuckConfigurableOptions | 'fields'> & {
-    fields: Omit<FieldConfigurationWithDefinition<P, true>, 'content'>;
-  } = {
+  const finalRootConfig: Omit<
+    CustomRootConfigWithDefinition<InternalRootData & InternalRootComponentFields>,
+    IgnorePuckConfigurableOptions
+  > = {
     ...updatedRootConfig,
     // @ts-expect-error - objects are typed above, they just can't be combined here
-    fields: {
-      ...fields,
-      ...internalFields,
-    },
+    fields: updatedRootConfig.fields,
     // Create a render function that calls all root render functions
-    render({ _styleOverrides, content: Content, puck, editMode = false, id, ...props }) {
-      // eslint-disable-next-line react-hooks/rules-of-hooks
-      const editorElements = usePuckIframeElements();
-      // eslint-disable-next-line react-hooks/rules-of-hooks
-      const dashboard = useGlobalStore(state => state.dashboardWithoutData);
-
-      // gather all root config styles to apply globally
-      const allCustomStyles = processedConfigs
-        .map(rootConfig => {
-          const additionalProps: AdditionalRenderProps = {
-            _id: id,
-            _editMode: editMode ?? puck.isEditing,
-            _activeBreakpoint: props._activeBreakpoint as keyof AvailableQueries,
-            _editor: editorElements,
-            _dashboard: dashboard,
-          };
-          const propsForThisRoot = getPropsForRoot(rootConfig, props, additionalProps);
-          if (rootConfig.styles) {
-            // @ts-expect-error - this is fine, internal styles can't consume the `P` generic at this level
-            return rootConfig.styles(propsForThisRoot);
-          }
-          return '';
-        })
-        .join('\n');
-
+    render(renderProps: RenderProps<InternalRootData & InternalRootComponentFields>) {
       return (
-        <>
-          {processedConfigs.map((rootConfig, index) => {
-            if (rootConfig?.render) {
-              const additionalProps: AdditionalRenderProps = {
-                _id: id,
-                _editMode: editMode,
-                _activeBreakpoint: props._activeBreakpoint as keyof AvailableQueries,
-                _editor: editorElements,
-                _dashboard: dashboard,
-              };
-              const propsForThisRoot = getPropsForRoot(rootConfig, props, additionalProps);
-              return (
-                <ComponentRenderErrorBoundary componentConfig={rootConfig} key={rootConfig._remoteRepositoryId || index}>
-                  {/* @ts-expect-error - don't want to type this out, we'd have to cast anyway */}
-                  {rootConfig.render(propsForThisRoot)}
-                </ComponentRenderErrorBoundary>
-              );
-            }
-            return null;
-          })}
-          {/* the root dropzone */}
-          <Content />
-
-          <Global
-            styles={css`
-              /* Global styles for the dashboard */
-              ${allCustomStyles ?? ''}
-              /* Style overrides for the root component */
-              ${_styleOverrides?.style ?? ''}
-            `}
-          />
-        </>
+        <ComponentRenderErrorBoundary prefix='Root'>
+          <Render {...renderProps} remoteKeys={remoteKeys} processedConfigs={processedConfigs} />
+        </ComponentRenderErrorBoundary>
       );
     },
   };
   // @ts-expect-error - side effect of dodgeyness, but it does exist so we should remove it
   delete finalRootConfig._remoteRepositoryId; // Remove renderProps as it's not needed in the final config
   return finalRootConfig;
+}
+
+function getPropsForRoot<P extends DefaultComponentProps>(
+  rootConfig: CustomRootConfigWithRemote<P>,
+  props: Record<string, unknown>,
+  additionalProps: AdditionalRenderProps,
+  remoteKeys: Set<string>
+) {
+  // Create a new props object without any remote keys
+  // trim off any remote objects that do not match the current rootConfig
+  const baseProps = Object.fromEntries(Object.entries(props).filter(([key]) => !remoteKeys.has(key)));
+  // Get the current remote's props and spread them at the top level
+  const currentRemoteProps = props[rootConfig._remoteRepositoryId] || {};
+  // Combine base props with current remote's props and style overrides
+  const propsForThisRoot = {
+    // ...props, // Start with all original props to ensure required props are present
+    ...baseProps, // Override with filtered base props (without other remotes)
+    ...(typeof currentRemoteProps === 'object' && currentRemoteProps !== null ? currentRemoteProps : {}),
+    ...additionalProps,
+  };
+  return propsForThisRoot;
+}
+
+function Render<P extends DefaultComponentProps>({
+  puck,
+  processedConfigs,
+  remoteKeys,
+  ...props
+}: RenderProps<InternalRootData & InternalRootComponentFields> & {
+  processedConfigs: CustomRootConfigWithRemote<P>[];
+  remoteKeys: Set<string>;
+}) {
+  const editorElements = usePuckIframeElements();
+  const { id, styles, editMode = false, content: Content } = props;
+
+  const dashboard = useGlobalStore(state => state.dashboardWithoutData);
+
+  // gather all root config styles to apply globally
+  const allCustomStyles = processedConfigs
+    .map(rootConfig => {
+      const additionalProps: AdditionalRenderProps = {
+        _id: id,
+        _editMode: editMode ?? puck.isEditing,
+        _editor: editorElements,
+        _dashboard: dashboard,
+      };
+      const propsForThisRoot = getPropsForRoot(rootConfig, props, additionalProps, remoteKeys);
+      if (rootConfig.styles) {
+        // @ts-expect-error - this is fine, internal styles can't consume the `P` generic at this level
+        return rootConfig.styles(propsForThisRoot);
+      }
+      return '';
+    })
+    .join('\n');
+
+  return (
+    <>
+      {processedConfigs.map((rootConfig, index) => {
+        if (rootConfig?.render) {
+          const additionalProps: AdditionalRenderProps = {
+            _id: id,
+            _editMode: editMode,
+            _editor: editorElements,
+            _dashboard: dashboard,
+          };
+          const propsForThisRoot = getPropsForRoot(rootConfig, props, additionalProps, remoteKeys);
+          // @ts-expect-error - don't want to type this out, we'd have to cast anyway */
+          return <Fragment key={index}>{rootConfig.render(propsForThisRoot)}</Fragment>;
+        }
+        return null;
+      })}
+      {/* the root dropzone */}
+      <Content />
+
+      <Global
+        styles={css`
+          /* Global styles for the dashboard */
+          ${allCustomStyles ?? ''}
+          /* Style overrides for the root component */
+          ${styles?.css ?? ''}
+        `}
+      />
+    </>
+  );
 }

--- a/packages/editor/src/helpers/editor/internalFields/index.tsx
+++ b/packages/editor/src/helpers/editor/internalFields/index.tsx
@@ -1,17 +1,23 @@
-import { AvailableQueries } from '@hakit/components';
-import { FieldConfiguration } from '@typings/fields';
+import { FieldConfiguration, InternalComponentFields, InternalRootComponentFields } from '@typings/fields';
+import { useEffect } from 'react';
+import { useActiveBreakpoint } from '@hooks/useActiveBreakpoint';
 
-interface InternalRootComponentFields {
-  _activeBreakpoint: keyof AvailableQueries;
-  styles: {
-    css: string;
-  };
-}
-
-export const rootComponentFields: FieldConfiguration<InternalRootComponentFields> = {
+export const internalRootComponentFields: FieldConfiguration<InternalRootComponentFields> = {
   _activeBreakpoint: {
-    type: 'hidden',
+    type: 'custom',
     default: 'xlg',
+    label: 'Active Breakpoint',
+    visible: () => false,
+    description: 'The active breakpoint for this component, used for responsive design',
+    render({ onChange, name }) {
+      // eslint-disable-next-line react-hooks/rules-of-hooks
+      const breakpoint = useActiveBreakpoint();
+      // eslint-disable-next-line react-hooks/rules-of-hooks
+      useEffect(() => {
+        onChange(breakpoint);
+      }, [onChange, breakpoint]);
+      return <input name={name} type='hidden' value={breakpoint} />;
+    },
   },
   styles: {
     type: 'object',
@@ -30,19 +36,27 @@ export const rootComponentFields: FieldConfiguration<InternalRootComponentFields
       },
     },
   },
+  content: {
+    type: 'slot',
+  },
 };
 
-interface InternalComponentFields {
-  _activeBreakpoint: keyof AvailableQueries;
-  styles: {
-    css: string;
-  };
-}
-
-export const componentFields: FieldConfiguration<InternalComponentFields> = {
+export const internalComponentFields: FieldConfiguration<InternalComponentFields> = {
   _activeBreakpoint: {
-    type: 'hidden',
+    type: 'custom',
     default: 'xlg',
+    label: 'Active Breakpoint',
+    description: 'The active breakpoint for this component, used for responsive design',
+    visible: () => false,
+    render({ onChange, name }) {
+      // eslint-disable-next-line react-hooks/rules-of-hooks
+      const breakpoint = useActiveBreakpoint();
+      // eslint-disable-next-line react-hooks/rules-of-hooks
+      useEffect(() => {
+        onChange(breakpoint);
+      }, [onChange, breakpoint]);
+      return <input name={name} type='hidden' value={breakpoint} />;
+    },
   },
   styles: {
     type: 'object',
@@ -59,7 +73,7 @@ export const componentFields: FieldConfiguration<InternalComponentFields> = {
         description: 'Provide css updates to override the default styles of this component',
         default: '',
         visible(data) {
-          return data.styles.css !== undefined;
+          return data.styles.css !== undefined && data._activeBreakpoint !== 'lg';
         },
       },
     },

--- a/packages/editor/src/helpers/editor/internalFields/index.tsx
+++ b/packages/editor/src/helpers/editor/internalFields/index.tsx
@@ -1,0 +1,67 @@
+import { AvailableQueries } from '@hakit/components';
+import { FieldConfiguration } from '@typings/fields';
+
+interface InternalRootComponentFields {
+  _activeBreakpoint: keyof AvailableQueries;
+  styles: {
+    css: string;
+  };
+}
+
+export const rootComponentFields: FieldConfiguration<InternalRootComponentFields> = {
+  _activeBreakpoint: {
+    type: 'hidden',
+    default: 'xlg',
+  },
+  styles: {
+    type: 'object',
+    label: 'Global styles',
+    collapseOptions: {
+      startExpanded: false,
+    },
+    description: 'Provide global CSS styles for the entire dashboard',
+    objectFields: {
+      css: {
+        type: 'code',
+        language: 'css',
+        label: 'CSS Styles',
+        description: 'Provide global CSS styles for the entire dashboard',
+        default: '',
+      },
+    },
+  },
+};
+
+interface InternalComponentFields {
+  _activeBreakpoint: keyof AvailableQueries;
+  styles: {
+    css: string;
+  };
+}
+
+export const componentFields: FieldConfiguration<InternalComponentFields> = {
+  _activeBreakpoint: {
+    type: 'hidden',
+    default: 'xlg',
+  },
+  styles: {
+    type: 'object',
+    label: 'Style Overrides',
+    collapseOptions: {
+      startExpanded: false,
+    },
+    description: 'Provide css updates to override the default styles of this component',
+    objectFields: {
+      css: {
+        type: 'code',
+        language: 'css',
+        label: 'CSS Styles',
+        description: 'Provide css updates to override the default styles of this component',
+        default: '',
+        visible(data) {
+          return data.styles.css !== undefined;
+        },
+      },
+    },
+  },
+};

--- a/packages/editor/src/helpers/editor/pageData/getDefaultPropsFromFields.ts
+++ b/packages/editor/src/helpers/editor/pageData/getDefaultPropsFromFields.ts
@@ -1,4 +1,4 @@
-import { ComponentData, DefaultComponentProps } from '@measured/puck';
+import { DefaultComponentProps } from '@measured/puck';
 import { DefaultPropsCallbackData } from '@typings/puck';
 import type { CustomFields, FieldConfiguration } from '@typings/fields';
 
@@ -6,7 +6,7 @@ import type { CustomFields, FieldConfiguration } from '@typings/fields';
  * Recursively gathers default values from fields definitions.
  */
 export async function getDefaultPropsFromFields<P extends DefaultComponentProps>(
-  fields: FieldConfiguration<P, Omit<ComponentData<P>, 'type'>['props']>,
+  fields: FieldConfiguration<P>,
   data: DefaultPropsCallbackData
 ): Promise<P> {
   const result: DefaultComponentProps = {};

--- a/packages/editor/src/helpers/editor/pageData/tests/getDefaultPropsFromFields.test.ts
+++ b/packages/editor/src/helpers/editor/pageData/tests/getDefaultPropsFromFields.test.ts
@@ -315,7 +315,15 @@ describe('getDefaultPropsFromFields', () => {
     });
 
     test('should handle complex nested structure with mixed types', async () => {
-      const fields: FieldConfiguration = {
+      const fields: FieldConfiguration<{
+        complexConfig: {
+          simpleField: string;
+          nestedObject: {
+            deepField: number;
+            undefinedDeepField?: undefined; // This should not become an empty object
+          };
+        };
+      }> = {
         complexConfig: {
           type: 'object',
           label: 'Complex Config',

--- a/packages/editor/src/helpers/editor/pageData/tests/puckToDBValue.test.tsx
+++ b/packages/editor/src/helpers/editor/pageData/tests/puckToDBValue.test.tsx
@@ -446,7 +446,12 @@ describe('puckToDBValue', () => {
 
   test('should handle fields with responsiveMode: true with the mode map as true', () => {
     // Create a modified config where number field has responsiveMode: true
-    const modifiedUserConfig = {
+    const prevNumberField = userConfig.components['Field Test'].fields.options._field.objectFields.number as any;
+    const updatedNumberField =
+      prevNumberField && prevNumberField.type === 'slot'
+        ? prevNumberField
+        : { ...prevNumberField, _field: { ...prevNumberField._field, responsiveMode: true } };
+    const modifiedUserConfig: typeof userConfig = {
       ...userConfig,
       components: {
         ...userConfig.components,
@@ -460,14 +465,7 @@ describe('puckToDBValue', () => {
                 ...userConfig.components['Field Test'].fields.options._field,
                 objectFields: {
                   ...userConfig.components['Field Test'].fields.options._field.objectFields,
-                  number: {
-                    ...userConfig.components['Field Test'].fields.options._field.objectFields.number,
-                    _field: {
-                      // @ts-expect-error - this is fine, _field doesn't exist on type slot
-                      ...userConfig.components['Field Test'].fields.options._field.objectFields.number._field,
-                      responsiveMode: true, // this field should have breakpoints
-                    },
-                  },
+                  number: updatedNumberField,
                 },
               },
             },

--- a/packages/editor/src/hooks/useGlobalStore.ts
+++ b/packages/editor/src/hooks/useGlobalStore.ts
@@ -52,6 +52,9 @@ type PuckConfigurationStore = {
   setEditorMode: (editorMode: boolean) => void;
   componentBreakpointMap: ComponentBreakpointModeMap;
   setComponentBreakpointMap: (componentBreakpointMap: ComponentBreakpointModeMap) => void;
+
+  componentError?: { message: string; title: string };
+  setComponentError: (error: { message: string; title: string }) => void;
 };
 
 export const useGlobalStore = create<PuckConfigurationStore>(set => {
@@ -117,5 +120,7 @@ export const useGlobalStore = create<PuckConfigurationStore>(set => {
     },
     setEditorMode: (editorMode: boolean) => set(state => ({ ...state, editorMode })),
     editorMode: false,
+    componentError: undefined,
+    setComponentError: (error: { message: string; title: string }) => set(state => ({ ...state, componentError: error })),
   };
 });

--- a/packages/shared/typings/fields.ts
+++ b/packages/shared/typings/fields.ts
@@ -11,6 +11,7 @@ import type {
   ArrayField,
   SlotField as PuckSlotField,
   CustomField as PuckCustomField,
+  ComponentData,
 } from '@measured/puck';
 import type { ReactNode } from 'react';
 import type { DefaultPropsCallbackData } from './puck';
@@ -19,7 +20,7 @@ import type { OnValidate } from '@monaco-editor/react';
 
 type BaseField = Omit<PuckBaseField, 'visible'>;
 
-export type ExtendedFieldTypes<DataShape = unknown> = {
+export type ExtendedFieldTypes<DataShape = unknown, Props = unknown> = {
   description?: string;
   icon?: ReactNode;
   readOnly?: boolean;
@@ -28,7 +29,7 @@ export type ExtendedFieldTypes<DataShape = unknown> = {
   /** If the field is required or not TODO - Test this */
   required?: boolean;
   /** The default value of the field if no value is saved or present */
-  default: unknown;
+  default: Props;
   /** if enabled, this field will be able to configure different values at different breakpoints @default true */
   responsiveMode?: boolean;
   /** Make the current field collapsible by providing this object, and a default state if desired @default undefined */
@@ -96,7 +97,7 @@ export type GridField = BaseField & {
   step?: number;
 };
 
-export type HiddenField = Pick<ExtendedFieldTypes, 'default' | 'responsiveMode'> & {
+export type HiddenField<DataShape = unknown, Props = unknown> = Pick<ExtendedFieldTypes<DataShape, Props>, 'default' | 'responsiveMode'> & {
   type: 'hidden';
 };
 
@@ -151,26 +152,26 @@ export type CustomFields<
   E extends DefaultComponentProps = DefaultComponentProps,
   DataShape = unknown,
 > =
-  | (Omit<TextField, ExcludePuckKeys> & ExtendedFieldTypes<DataShape> & E)
-  | (Omit<NumberField, ExcludePuckKeys> & ExtendedFieldTypes<DataShape> & E)
-  | (Omit<TextareaField, ExcludePuckKeys> & ExtendedFieldTypes<DataShape> & E)
-  | (Omit<SelectField, ExcludePuckKeys> & ExtendedFieldTypes<DataShape> & E)
-  | (Omit<RadioField, ExcludePuckKeys> & ExtendedFieldTypes<DataShape> & E)
-  | (Omit<PageField, ExcludePuckKeys> & ExtendedFieldTypes<DataShape> & E)
-  | (Omit<PagesField, ExcludePuckKeys> & ExtendedFieldTypes<DataShape> & E)
-  | (Omit<ServiceField, ExcludePuckKeys> & ExtendedFieldTypes<DataShape> & E)
-  | (Omit<ColorField, ExcludePuckKeys> & ExtendedFieldTypes<DataShape> & E)
-  | (Omit<ImageUploadField, ExcludePuckKeys> & ExtendedFieldTypes<DataShape> & E)
-  | (Omit<SliderField, ExcludePuckKeys> & ExtendedFieldTypes<DataShape> & E)
-  | (Omit<GridField, ExcludePuckKeys> & ExtendedFieldTypes<DataShape> & E)
-  | (Omit<CodeField, ExcludePuckKeys> & ExtendedFieldTypes<DataShape> & E)
-  | (Omit<SwitchField, ExcludePuckKeys> & ExtendedFieldTypes<DataShape> & E)
-  | (Omit<DividerField, ExcludePuckKeys> & ExtendedFieldTypes<DataShape> & E)
-  | (Omit<CustomArrayField<Props, E, DataShape>, ExcludePuckKeys> & ExtendedFieldTypes<DataShape> & E)
-  | (Omit<CustomObjectField<Props, E, DataShape>, ExcludePuckKeys> & Omit<ExtendedFieldTypes<DataShape>, 'default'> & E)
+  | (Omit<TextField, ExcludePuckKeys> & ExtendedFieldTypes<DataShape, Props> & E)
+  | (Omit<NumberField, ExcludePuckKeys> & ExtendedFieldTypes<DataShape, Props> & E)
+  | (Omit<TextareaField, ExcludePuckKeys> & ExtendedFieldTypes<DataShape, Props> & E)
+  | (Omit<SelectField, ExcludePuckKeys> & ExtendedFieldTypes<DataShape, Props> & E)
+  | (Omit<RadioField, ExcludePuckKeys> & ExtendedFieldTypes<DataShape, Props> & E)
+  | (Omit<PageField, ExcludePuckKeys> & ExtendedFieldTypes<DataShape, Props> & E)
+  | (Omit<PagesField, ExcludePuckKeys> & ExtendedFieldTypes<DataShape, Props> & E)
+  | (Omit<ServiceField, ExcludePuckKeys> & ExtendedFieldTypes<DataShape, Props> & E)
+  | (Omit<ColorField, ExcludePuckKeys> & ExtendedFieldTypes<DataShape, Props> & E)
+  | (Omit<ImageUploadField, ExcludePuckKeys> & ExtendedFieldTypes<DataShape, Props> & E)
+  | (Omit<SliderField, ExcludePuckKeys> & ExtendedFieldTypes<DataShape, Props> & E)
+  | (Omit<GridField, ExcludePuckKeys> & ExtendedFieldTypes<DataShape, Props> & E)
+  | (Omit<CodeField, ExcludePuckKeys> & ExtendedFieldTypes<DataShape, Props> & E)
+  | (Omit<SwitchField, ExcludePuckKeys> & ExtendedFieldTypes<DataShape, Props> & E)
+  | (Omit<DividerField, ExcludePuckKeys> & ExtendedFieldTypes<DataShape, Props> & E)
+  | (Omit<CustomArrayField<Props, E, DataShape>, ExcludePuckKeys> & ExtendedFieldTypes<DataShape, Props> & E)
+  | (Omit<CustomObjectField<Props, E, DataShape>, ExcludePuckKeys> & Omit<ExtendedFieldTypes<DataShape, Props>, 'default'> & E)
   | CustomField<Props, E>
   | SlotField
-  | (HiddenField & E)
+  | (HiddenField<DataShape, Props> & E)
   | (EntityField<DataShape> & E);
 
 export type CustomFieldsWithDefinition<Props extends DefaultComponentProps, DataShape = unknown> = CustomField<
@@ -185,7 +186,7 @@ export type CustomFieldsWithDefinition<Props extends DefaultComponentProps, Data
               DataShape
             >;
           };
-        } & ExtendedFieldTypes<DataShape>
+        } & ExtendedFieldTypes<DataShape, Props>
       : Props extends { [key: string]: any }
         ? Omit<ObjectField<Props>, 'objectFields' | 'visible'> & {
             objectFields: {
@@ -195,14 +196,17 @@ export type CustomFieldsWithDefinition<Props extends DefaultComponentProps, Data
                 DataShape
               >;
             };
-          } & Omit<ExtendedFieldTypes<DataShape>, 'default'>
+          } & Omit<ExtendedFieldTypes<DataShape, Props>, 'default'>
         : CustomFields<Props, object, DataShape>) & {
       repositoryId?: string;
     };
   }
 >;
 
-export type FieldConfiguration<ComponentProps extends DefaultComponentProps = DefaultComponentProps, DataShape = unknown> = {
+export type FieldConfiguration<
+  ComponentProps extends DefaultComponentProps = DefaultComponentProps,
+  DataShape = Omit<ComponentData<ComponentProps>, 'type'>['props'],
+> = {
   [PropName in keyof Omit<ComponentProps, 'editMode'>]: CustomFields<ComponentProps[PropName], object, DataShape>;
 };
 

--- a/packages/shared/typings/puck.ts
+++ b/packages/shared/typings/puck.ts
@@ -9,19 +9,17 @@ import {
   AsFieldProps,
   RootData,
 } from '@measured/puck';
-import { type AvailableQueries } from '@hakit/components';
 import { type HassEntities, type HassServices } from 'home-assistant-js-websocket';
 import type { Dashboard } from './hono';
-import type { FieldConfiguration, FieldConfigurationWithDefinition } from './fields';
-
-export type InternalFields = {
-  // breakpoint is not saved in the db, this is calculated on the fly
-  breakpoint: keyof AvailableQueries;
-};
+import type { FieldConfiguration, FieldConfigurationWithDefinition, InternalComponentFields, InternalRootComponentFields } from './fields';
 
 export type DefaultPropsCallbackData = {
   entities: HassEntities;
   services: HassServices | null;
+};
+
+export type InternalRootData = {
+  _remoteRepositoryId?: string; // Optional remote name for tracking
 };
 
 // Just for readability, this shouldn't ever change
@@ -32,7 +30,7 @@ export type AdditionalRenderProps = {
   _id: string; // Unique ID for the component instance
   _editMode: boolean; // Whether the component is being rendered in edit mode
   /** the hakit context, this houses additional information to send to each render of each component */
-  _activeBreakpoint: keyof AvailableQueries;
+  // _activeBreakpoint: keyof AvailableQueries;
   _dashboard: Dashboard | null;
   _editor?: {
     document: Document | null;
@@ -64,9 +62,9 @@ export type CustomComponentConfig<
   label: string;
   // Custom fields configuration instead of Puck's Fields
   fields: FieldConfiguration<Props, Omit<ComponentData<FieldProps>, 'type'>['props']>;
-  render: PuckComponent<Props & AdditionalRenderProps>;
+  render: PuckComponent<Props & InternalComponentFields & AdditionalRenderProps>;
   // Optional styles function that returns CSS string for component-scoped styling
-  styles?: (props: Props & AdditionalRenderProps) => string;
+  styles?: (props: Props & InternalComponentFields & AdditionalRenderProps) => string;
   // defaultProps is intentionally omitted, we handle this on individual field definitions
 };
 
@@ -79,9 +77,9 @@ export type CustomComponentConfigWithDefinition<
   label: string;
   // Custom fields configuration instead of Puck's Fields
   fields: FieldConfigurationWithDefinition<Props, Omit<ComponentData<FieldProps>, 'type'>['props']>;
-  render: PuckComponent<Props & AdditionalRenderProps>;
+  render: PuckComponent<Props & InternalComponentFields & AdditionalRenderProps>;
   // Optional styles function that returns CSS string for component-scoped styling
-  styles?: (props: Props & AdditionalRenderProps) => string;
+  styles?: (props: Props & InternalComponentFields & AdditionalRenderProps) => string;
   // defaultProps is intentionally omitted, we handle this on individual field definitions
 };
 
@@ -109,7 +107,7 @@ export type CustomConfigWithDefinition<
     [ComponentName in keyof Props]: Omit<CustomComponentConfigWithDefinition<Props[ComponentName], Props[ComponentName]>, 'type'>;
   };
   fields?: FieldConfigurationWithDefinition<Props, true>;
-  root?: CustomRootConfigWithDefinition<RootProps>;
+  root?: CustomRootConfigWithDefinition<InternalRootData & InternalRootComponentFields>;
 };
 
 export type Slot = InternalSlot;


### PR DESCRIPTION
- Error boundaries added for Root and standard components, even when a component fails, you can still remove it or move it, will no longer render the children of the iframe until the cache is ready to avoid paint flashing
- Default internal field structure now scaleable
- Updated types that were incorrect in many places
- Improved emotion cache, removed duplicate theme provider
- isVisible will now simply hide the component rather than not render it