### PR TITLE
Updating tests for global module mocker

### DIFF
--- a/happydom.ts
+++ b/happydom.ts
@@ -1,3 +1,15 @@
 import { GlobalRegistrator } from '@happy-dom/global-registrator';
 
 GlobalRegistrator.register();
+
+// Ensure requestAnimationFrame exists for libraries that rely on it during tests
+declare global {
+  interface Window {
+    requestAnimationFrame?: (cb: FrameRequestCallback) => number;
+  }
+}
+
+const globalWindow: Window = globalThis as unknown as Window;
+if (typeof globalWindow.requestAnimationFrame !== 'function') {
+  globalWindow.requestAnimationFrame = (callback: FrameRequestCallback) => setTimeout(callback, 16) as unknown as number;
+}

--- a/packages/editor/src/features/dashboard/Editor/EditorShortcuts/EditorShortcuts.test.tsx
+++ b/packages/editor/src/features/dashboard/Editor/EditorShortcuts/EditorShortcuts.test.tsx
@@ -2,44 +2,15 @@ import { expect, test, describe, beforeEach, afterAll, mock } from 'bun:test';
 import { render } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { createElement } from 'react';
+import { createModuleMocker } from '@test-utils/moduleMocker';
 
 /**
  * Due to an issue with Bun (https://github.com/oven-sh/bun/issues/7823), we need to manually restore mocked modules
  * after we're done. We do this by setting the mocked value to the original module.
  */
-interface MockResult {
-  clear: () => void;
-}
-
-export class ModuleMocker {
-  private mocks: MockResult[] = [];
-
-  async mock(modulePath: string, renderMocks: () => Record<string, unknown>) {
-    const original = {
-      ...(await import(modulePath)),
-    };
-    const mocks = renderMocks();
-    const result = {
-      ...original,
-      ...mocks,
-    };
-    mock.module(modulePath, () => result);
-
-    this.mocks.push({
-      clear: () => {
-        mock.module(modulePath, () => original);
-      },
-    });
-  }
-
-  clear() {
-    this.mocks.forEach(mockResult => mockResult.clear());
-    this.mocks = [];
-  }
-}
 
 // Set up module mocker at top level
-const moduleMocker = new ModuleMocker();
+const moduleMocker = createModuleMocker();
 
 // Mock functions for testing
 const mockNavigate = mock(() => {});
@@ -120,8 +91,7 @@ describe('EditorShortcuts', () => {
   });
 
   afterAll(() => {
-    // Clear all module mocks to prevent pollution of other tests
-    moduleMocker.clear();
+    // No-op: cleanup handled by createModuleMocker()
   });
 
   test('should create component without throwing', () => {

--- a/packages/editor/src/features/dashboard/Renderer/RendererShortcuts/RendererShortcuts.test.tsx
+++ b/packages/editor/src/features/dashboard/Renderer/RendererShortcuts/RendererShortcuts.test.tsx
@@ -2,44 +2,15 @@ import { expect, test, describe, beforeEach, afterAll, mock } from 'bun:test';
 import { render } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { createElement } from 'react';
+import { createModuleMocker } from '@test-utils/moduleMocker';
 
 /**
  * Due to an issue with Bun (https://github.com/oven-sh/bun/issues/7823), we need to manually restore mocked modules
  * after we're done. We do this by setting the mocked value to the original module.
  */
-interface MockResult {
-  clear: () => void;
-}
-
-export class ModuleMocker {
-  private mocks: MockResult[] = [];
-
-  async mock(modulePath: string, renderMocks: () => Record<string, unknown>) {
-    const original = {
-      ...(await import(modulePath)),
-    };
-    const mocks = renderMocks();
-    const result = {
-      ...original,
-      ...mocks,
-    };
-    mock.module(modulePath, () => result);
-
-    this.mocks.push({
-      clear: () => {
-        mock.module(modulePath, () => original);
-      },
-    });
-  }
-
-  clear() {
-    this.mocks.forEach(mockResult => mockResult.clear());
-    this.mocks = [];
-  }
-}
 
 // Set up module mocker at top level
-const moduleMocker = new ModuleMocker();
+const moduleMocker = createModuleMocker();
 
 // Mock functions for testing
 const mockNavigate = mock(() => {});
@@ -85,8 +56,7 @@ describe('RendererShortcuts', () => {
   });
 
   afterAll(() => {
-    // Clear all module mocks to prevent pollution of other tests
-    moduleMocker.clear();
+    // No-op: cleanup handled by createModuleMocker()
   });
 
   test('should create component without throwing', () => {

--- a/packages/editor/src/helpers/editor/createPuckComponent/createComponent.test.tsx
+++ b/packages/editor/src/helpers/editor/createPuckComponent/createComponent.test.tsx
@@ -1,49 +1,14 @@
-import { expect, test, describe, beforeEach, afterAll, mock } from 'bun:test';
+import { expect, test, describe, beforeEach, mock } from 'bun:test';
 import { createElement } from 'react';
+import { createModuleMocker } from '@test-utils/moduleMocker';
 
 /**
  * Due to an issue with Bun (https://github.com/oven-sh/bun/issues/7823), we need to manually restore mocked modules
  * after we're done. We do this by setting the mocked value to the original module.
  */
-interface MockResult {
-  clear: () => void;
-}
-
-export class ModuleMocker {
-  private mocks: MockResult[] = [];
-
-  async mock(modulePath: string, renderMocks: () => Record<string, unknown>) {
-    const original = {
-      ...(await import(modulePath)),
-    };
-    const mocks = renderMocks();
-    const result = {
-      ...original,
-      ...mocks,
-    };
-    mock.module(modulePath, () => result);
-
-    this.mocks.push({
-      clear: () => {
-        mock.module(modulePath, () => original);
-      },
-    });
-  }
-
-  clear() {
-    this.mocks.forEach(mockResult => mockResult.clear());
-    this.mocks = [];
-  }
-}
-
-// Mock window and leaflet to prevent import issues
-(global as { window?: unknown }).window = {
-  setTimeout: setTimeout,
-  requestAnimationFrame: (fn: () => void) => setTimeout(fn, 16),
-};
 
 // Set up module mocker at top level
-const moduleMocker = new ModuleMocker();
+const moduleMocker = createModuleMocker();
 
 await moduleMocker.mock('@hakit/components', () => ({
   AvailableQueries: {},
@@ -104,11 +69,6 @@ describe('createComponent', () => {
     mockUseActiveBreakpoint.mockClear();
     mockUseGlobalStore.mockClear();
     mockUsePuckIframeElements.mockClear();
-  });
-
-  afterAll(() => {
-    // Clear all module mocks to prevent pollution of other tests
-    moduleMocker.clear();
   });
 
   const createMockComponentFactoryData = (): ComponentFactoryData => ({

--- a/packages/editor/src/test-utils/moduleMocker.ts
+++ b/packages/editor/src/test-utils/moduleMocker.ts
@@ -1,0 +1,40 @@
+import { afterAll, mock } from 'bun:test';
+
+interface MockResult {
+  clear: () => void;
+}
+
+export class ModuleMocker {
+  private mocks: MockResult[] = [];
+
+  async mock(modulePath: string, renderMocks: () => Record<string, unknown>) {
+    const original = {
+      ...(await import(modulePath)),
+    };
+    const mocks = renderMocks();
+    const result = {
+      ...original,
+      ...mocks,
+    };
+    mock.module(modulePath, () => result);
+
+    this.mocks.push({
+      clear: () => {
+        mock.module(modulePath, () => original);
+      },
+    });
+  }
+
+  clear() {
+    this.mocks.forEach(mockResult => mockResult.clear());
+    this.mocks = [];
+  }
+}
+
+export function createModuleMocker(): ModuleMocker {
+  const moduleMocker = new ModuleMocker();
+  afterAll(() => {
+    moduleMocker.clear();
+  });
+  return moduleMocker;
+}

--- a/packages/editor/tsconfig.json
+++ b/packages/editor/tsconfig.json
@@ -30,7 +30,8 @@
       "@constants": ["./src/constants/index.ts"],
       "@components/*": ["./src/components/*"],
       "@server/*": ["../server/*"],
-      "@shared/*": ["../shared/*"]
+      "@shared/*": ["../shared/*"],
+      "@test-utils/*": ["./src/test-utils/*"]
     }
   },
   "include": ["src/**/*", "./.d.ts"],


### PR DESCRIPTION
This pull request refactors test utilities and improves type safety and compatibility in the `SelectField` component, while also ensuring better test environment setup. The main changes include moving the `ModuleMocker` utility to a shared location and updating its usage across tests, simplifying the `SelectField` API, and adding a polyfill for `requestAnimationFrame` to support libraries during tests.

**Test utilities refactor and usage improvements:**

* Moved the `ModuleMocker` utility to `packages/editor/src/test-utils/moduleMocker.ts`, exported a `createModuleMocker` function, and ensured cleanup is handled automatically via `afterAll`. Updated all test files to use `createModuleMocker` instead of duplicating the class, and removed manual cleanup calls. [[1]](diffhunk://#diff-7b05d0e710c8e807e43a60fe07321b624cd9030e4f114239fd22af086515dd35R1-R40) [[2]](diffhunk://#diff-66b813273ec877f1fade9db832987bdfb234c79737bc34b7213b225e1f1601f7R5-R13) [[3]](diffhunk://#diff-66b813273ec877f1fade9db832987bdfb234c79737bc34b7213b225e1f1601f7L123-R94) [[4]](diffhunk://#diff-2610b29149e0efbe510a421b08c195cd0a5264e0b769d9dc30700c3b445338c3R5-R13) [[5]](diffhunk://#diff-2610b29149e0efbe510a421b08c195cd0a5264e0b769d9dc30700c3b445338c3L88-R59) [[6]](diffhunk://#diff-ce4140a68616fdad87c9e30ce650595fcc7a19e049aa97779328105fb5e817e3L1-R11) [[7]](diffhunk://#diff-ce4140a68616fdad87c9e30ce650595fcc7a19e049aa97779328105fb5e817e3L109-L113)
* Updated `tsconfig.json` to support the new `@test-utils/*` path alias for test utilities.

**SelectField component API simplification and type improvements:**

* Simplified the `SelectField` API by using `SelectProps<Value>['onChange']` for the `onChange` prop, passing the actual `value` to the underlying MUI `Select`, and updating `getOptionLabel` to accept `Option | Value`. Removed custom handling for selected index and event transformation.
* Improved `renderValue` logic in `SelectField` to directly use `getOptionLabel(selected)` for label rendering, and ensured correct prop typing when spreading props.
* Removed unused `SelectChangeEvent` import from `SelectField`.

**Test environment setup:**

* Added a polyfill for `window.requestAnimationFrame` in `happydom.ts` to ensure compatibility with libraries that rely on it during tests.

These changes collectively improve code maintainability, type safety, and reliability of tests across the codebase.