### PR TITLE
Reset component and reset field to defaults

### DIFF
--- a/packages/editor/src/components/Form/Field/Switch/SwitchField.module.css
+++ b/packages/editor/src/components/Form/Field/Switch/SwitchField.module.css
@@ -57,7 +57,7 @@
   width: var(--switch-thumb-size, 1rem); /* 16px */
   height: var(--switch-thumb-size, 1rem); /* 16px */
   border-radius: 50%;
-  background-color: var(--clr-primary-a30);
+  background-color: var(--clr-primary-a80);
   transition: transform var(--transition-normal);
   box-shadow: var(--shadow-sm);
 }

--- a/packages/editor/src/components/Form/Field/Switch/index.tsx
+++ b/packages/editor/src/components/Form/Field/Switch/index.tsx
@@ -19,7 +19,7 @@ export type SwitchFieldProps = {
   icon?: React.ReactNode;
   readOnly?: boolean;
   /** should the switch be wrapped in a container matching other input styles @default true */
-  isolated?: boolean;
+  withContainer?: boolean;
 } & Omit<React.InputHTMLAttributes<HTMLInputElement>, 'type' | 'checked' | 'size'>;
 
 // Define size-specific CSS custom properties
@@ -54,19 +54,19 @@ export function SwitchField({
   name,
   icon,
   readOnly,
-  isolated = true,
+  withContainer = true,
   ...inputProps
 }: SwitchFieldProps) {
   const containerClasses = getClassName(
     {
       Switch: true,
-      'container--isolated': isolated,
+      'container--isolated': withContainer,
       disabled: inputProps.disabled || readOnly,
     },
     className
   );
   const switchWrapperClasses = getClassName('switchWrapper', {
-    isolated: isolated,
+    isolated: withContainer,
   });
 
   return (

--- a/packages/editor/src/components/Menu/Menu.tsx
+++ b/packages/editor/src/components/Menu/Menu.tsx
@@ -105,6 +105,9 @@ export type MenuProps = {
   anchorRef?: React.RefObject<HTMLElement | null>;
   /** To stop menu's moving around in certain scenarios, we can stop the auto update functionality by providing this prop @default false */
   disableAutoPositioning?: boolean;
+
+  /** Called whenever the menu closes internally (not just via props) */
+  onClose?: () => void;
 };
 
 export const Menu = forwardRef<MenuControllerRef, MenuProps>(function Menu(
@@ -119,6 +122,7 @@ export const Menu = forwardRef<MenuControllerRef, MenuProps>(function Menu(
     iframeDocument = null,
     anchorRef,
     disableAutoPositioning = false,
+    onClose,
   },
   ref
 ) {
@@ -300,6 +304,14 @@ export const Menu = forwardRef<MenuControllerRef, MenuProps>(function Menu(
     }),
     [open, setOpen, refs, floatingStyles, context, getReferenceProps, getFloatingProps, activeIndex, selectedIndex, onSelectIndex]
   );
+
+  const prevOpenRef = useRef(open);
+  useEffect(() => {
+    if (prevOpenRef.current && !open && onClose) {
+      onClose();
+    }
+    prevOpenRef.current = open;
+  }, [open, onClose]);
 
   return (
     <Ctx.Provider value={value}>

--- a/packages/editor/src/components/Menu/MenuDivider.module.css
+++ b/packages/editor/src/components/Menu/MenuDivider.module.css
@@ -1,0 +1,5 @@
+.menuDivider {
+  height: 1px;
+  background-color: var(--clr-surface-a60);
+  margin: var(--space-1) 0;
+}

--- a/packages/editor/src/components/Menu/MenuDivider.tsx
+++ b/packages/editor/src/components/Menu/MenuDivider.tsx
@@ -1,0 +1,5 @@
+import styles from './MenuDivider.module.css';
+
+export function MenuDivider() {
+  return <div className={styles.menuDivider} />;
+}

--- a/packages/editor/src/components/Menu/MenuItemInner.module.css
+++ b/packages/editor/src/components/Menu/MenuItemInner.module.css
@@ -21,7 +21,6 @@
   color: var(--item-color);
   border: 0;
   outline: none;
-  border-bottom: 1px solid var(--clr-surface-a60);
   text-align: left;
   font-size: var(--font-size-sm);
   line-height: var(--line-height-normal);
@@ -31,7 +30,6 @@
     border-top-right-radius: var(--radius-lg);
   }
   &:last-of-type {
-    border-bottom:0;
     border-bottom-left-radius: var(--radius-lg);
     border-bottom-right-radius: var(--radius-lg);
   }
@@ -59,7 +57,7 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 1rem;
+  min-width: 1rem;
   height: 1rem;
 }
 

--- a/packages/editor/src/components/Menu/index.tsx
+++ b/packages/editor/src/components/Menu/index.tsx
@@ -1,2 +1,3 @@
 export { Menu, type MenuProps, MenuAnchor, MenuContent, type MenuContext, useMenuController, type MenuControllerRef } from './Menu';
 export { MenuItem, type MenuItemProps } from './MenuItem';
+export { MenuDivider } from './MenuDivider';

--- a/packages/editor/src/features/dashboard/Editor/FieldContainer/FieldOptions/index.tsx
+++ b/packages/editor/src/features/dashboard/Editor/FieldContainer/FieldOptions/index.tsx
@@ -1,27 +1,26 @@
 import { SwitchField } from '@components/Form/Field/Switch';
-import { Column } from '@components/Layout';
-import { Modal } from '@components/Modal';
 import { FieldConfiguration } from '@typings/fields';
-import { CodeXml, Touchpad } from 'lucide-react';
+import { InfoIcon, RotateCcw, Settings } from 'lucide-react';
 import { useFieldBreakpointConfig } from '@hooks/useFieldBreakpointConfig';
 import { useCallback, useEffect, useRef } from 'react';
+import { Menu, MenuAnchor, MenuContent, MenuDivider, MenuItem } from '@components/Menu';
+import { IconButton } from '@components/Button';
+import { Tooltip } from '@components/Tooltip';
 
 export function FieldOptions({
-  open,
   field,
-  onClose,
   name,
   allowTemplates,
   onResponsiveToggleChange,
   onTemplateToggleChange,
+  onResetToDefault,
   templateMode,
 }: {
-  open: boolean;
   field: Exclude<FieldConfiguration[string], { type: 'slot' | 'hidden' | 'object' | 'array' | 'hidden' }>;
-  onClose: () => void;
   name: string;
   onResponsiveToggleChange: (value: boolean) => void;
   onTemplateToggleChange: (value: boolean) => void;
+  onResetToDefault: () => void;
   templateMode: boolean;
   allowTemplates: boolean;
 }) {
@@ -41,8 +40,7 @@ export function FieldOptions({
 
   // Handle breakpoint mode toggle
   const handleBreakpointModeToggle = useCallback(
-    (event: React.ChangeEvent<HTMLInputElement>) => {
-      const checked = event.target.checked;
+    (checked: boolean) => {
       if (checked !== isBreakpointModeEnabled) {
         pendingToggleRef.current = true;
         toggleBreakpointMode();
@@ -52,34 +50,81 @@ export function FieldOptions({
   );
 
   return (
-    <Modal open={open} onClose={onClose} title={`Field options`} description={`Configure options for the "${field.label}" field.`}>
-      <Column fullWidth alignItems='flex-start' justifyContent='flex-start' gap='var(--space-4)' wrap='nowrap'>
-        <SwitchField
-          label='Responsive Mode'
-          checked={isBreakpointModeEnabled}
-          onChange={handleBreakpointModeToggle}
+    <Menu>
+      <MenuAnchor>
+        <IconButton
+          aria-label='Field options'
+          icon={<Settings size={16} />}
+          variant='transparent'
+          size='xs'
+          tooltipProps={{
+            placement: 'left',
+          }}
+        />
+      </MenuAnchor>
+      <MenuContent>
+        <MenuItem
+          label='Device Values'
           disabled={!responsiveMode}
-          icon={<Touchpad size={16} />}
-          helperText={
-            responsiveMode
-              ? 'Enable responsive mode for this field, this will allow you to configure different values for this field at different breakpoints.'
-              : 'This field does not allow responsive values to be set. This is configured by the field definition.'
+          onClick={() => handleBreakpointModeToggle(!isBreakpointModeEnabled)}
+          startIcon={
+            <Tooltip
+              style={{
+                display: 'flex',
+              }}
+              title={
+                responsiveMode
+                  ? 'Enable device values to set different values for each configured device.'
+                  : "This field doesn't support device-specific values. It's fixed by the field's configuration."
+              }
+            >
+              <InfoIcon size={16} />
+            </Tooltip>
           }
-          id='responsive-mode'
-          name='responsive-mode'
+          endIcon={
+            <SwitchField
+              size='small'
+              withContainer={false}
+              checked={isBreakpointModeEnabled}
+              disabled={!responsiveMode}
+              id='responsive-mode'
+            />
+          }
         />
         {allowTemplates && (
-          <SwitchField
-            label='Template Mode'
-            checked={templateMode}
-            onChange={e => onTemplateToggleChange(e.target.checked)}
-            icon={<CodeXml size={16} />}
-            helperText='Enable template mode for this field, this will allow you to use home assistant templates for this field value'
-            id='template-mode'
-            name='template-mode'
+          <MenuItem
+            startIcon={
+              <Tooltip
+                style={{
+                  display: 'flex',
+                }}
+                title='Use a Home Assistant template to dynamically set this field’s value.'
+              >
+                <InfoIcon size={16} />
+              </Tooltip>
+            }
+            onClick={() => onTemplateToggleChange(!templateMode)}
+            label='Template Value'
+            endIcon={<SwitchField size='small' withContainer={false} checked={templateMode} id='template-mode' />}
           />
         )}
-      </Column>
-    </Modal>
+        <MenuDivider />
+        <MenuItem
+          label='Reset to Default'
+          onClick={onResetToDefault}
+          startIcon={
+            <Tooltip
+              title='Reset this field to its default value'
+              style={{
+                display: 'flex',
+              }}
+            >
+              <InfoIcon size={16} />
+            </Tooltip>
+          }
+          endIcon={<RotateCcw size={16} />}
+        />
+      </MenuContent>
+    </Menu>
   );
 }

--- a/packages/editor/src/features/dashboard/Editor/PuckLayout/Toolbar/ViewportControls/index.tsx
+++ b/packages/editor/src/features/dashboard/Editor/PuckLayout/Toolbar/ViewportControls/index.tsx
@@ -454,7 +454,7 @@ const ViewportControlsComponent = () => {
                     aria-label={`Status ${item.id}`}
                     label='Status'
                     size='small'
-                    isolated={false}
+                    withContainer={false}
                     checked={!item.disabled}
                     onChange={event => onStatusChange(item.id, (event.target as HTMLInputElement).checked)}
                   />

--- a/packages/editor/src/features/me/addons/AddonsManager/index.tsx
+++ b/packages/editor/src/features/me/addons/AddonsManager/index.tsx
@@ -308,7 +308,7 @@ export function AddonsManager() {
                               <TableCell>
                                 <div className={getClassName('statusContainer')}>
                                   <SwitchField
-                                    isolated={false}
+                                    withContainer={false}
                                     id={`${component.name}-${index}`}
                                     name={`${component.name}-${index}`}
                                     checked={component.enabled ?? true}

--- a/packages/editor/src/hooks/useElementSizeChange.ts
+++ b/packages/editor/src/hooks/useElementSizeChange.ts
@@ -4,7 +4,7 @@ export interface ElementSize {
   width: number;
   height: number;
 }
-
+// UNUSED!
 export function useElementSizeChange(ref: RefObject<HTMLElement | null>, onChange: (size: ElementSize) => void) {
   useEffect(() => {
     const element = ref.current;


### PR DESCRIPTION
This pull request introduces several improvements to the editor's UI, focusing on enhancing the menu and field options experience. The main changes include adding a reusable `MenuDivider` component, refactoring the field options modal into a contextual menu with new actions, and updating the `SwitchField` API for better clarity. Additionally, a "Reset to Default" action is now available for both fields and components, improving usability and consistency.

**Menu and Field Options Enhancements:**

- Introduced a new `MenuDivider` component for visually separating menu items and integrated it throughout the UI. [[1]](diffhunk://#diff-28ef33fc701752378ef3ef01a8a955a1f6b83bfd9bf7af3c656dc8c3556c6e88R1-R5) [[2]](diffhunk://#diff-792e1b43f1a56537b82dea087a53c5c89d733d58762964a743baee571405d024R1-R5) [[3]](diffhunk://#diff-43e26d81b9c1a2348cb9ddafa799f5eef93cd50cec4d623b578e30dfe3405b2cR3) [[4]](diffhunk://#diff-975e7dac3d797ed7deb7ba736d6be6ef4039e0786937a00779b141dfc933255aL2-R8) [[5]](diffhunk://#diff-975e7dac3d797ed7deb7ba736d6be6ef4039e0786937a00779b141dfc933255aR127-R129)
- Refactored `FieldOptions` from a modal to a contextual menu, adding actions for toggling device values, template mode, and a new "Reset to Default" option. [[1]](diffhunk://#diff-ccd866453fbaca79bb947814b35e5025af900111589e7f5978705b31c9b397e7L2-R23) [[2]](diffhunk://#diff-ccd866453fbaca79bb947814b35e5025af900111589e7f5978705b31c9b397e7L44-R43) [[3]](diffhunk://#diff-ccd866453fbaca79bb947814b35e5025af900111589e7f5978705b31c9b397e7L55-R128) [[4]](diffhunk://#diff-9e1d46d7179881f084928c0b4566496ec5ba72847feb3bae6e21efd9fc3bdf35L51-R53) [[5]](diffhunk://#diff-9e1d46d7179881f084928c0b4566496ec5ba72847feb3bae6e21efd9fc3bdf35L116-R149) [[6]](diffhunk://#diff-9e1d46d7179881f084928c0b4566496ec5ba72847feb3bae6e21efd9fc3bdf35L158-L165) [[7]](diffhunk://#diff-9e1d46d7179881f084928c0b4566496ec5ba72847feb3bae6e21efd9fc3bdf35L205-L214)
- Added a "Reset to defaults" action to the shared component action bar, allowing users to quickly revert components to their default state. [[1]](diffhunk://#diff-975e7dac3d797ed7deb7ba736d6be6ef4039e0786937a00779b141dfc933255aR82-R110) [[2]](diffhunk://#diff-975e7dac3d797ed7deb7ba736d6be6ef4039e0786937a00779b141dfc933255aR127-R129)

**SwitchField API and Style Updates:**

- Renamed the `isolated` prop to `withContainer` in `SwitchField` for clearer intent and updated all usages accordingly. [[1]](diffhunk://#diff-3ef2e8c0a692059bf9bf76ec6a2b4a89dfb92632f17edddeba832204367a79efL22-R22) [[2]](diffhunk://#diff-3ef2e8c0a692059bf9bf76ec6a2b4a89dfb92632f17edddeba832204367a79efL57-R69) [[3]](diffhunk://#diff-3ae154f2a91d5f5cc02fc6caf51106fbad22e4c1a45e90467be5a029aa8af225L457-R457)
- Improved `SwitchField` thumb color for better visibility.

**Menu Component Improvements:**

- Added an `onClose` callback to the `Menu` component, enabling better control and side-effects when menus close. [[1]](diffhunk://#diff-0dca34e50a1813e7353054cc6443b3851f9cdd060b828fd399676944b9355bb3R108-R110) [[2]](diffhunk://#diff-0dca34e50a1813e7353054cc6443b3851f9cdd060b828fd399676944b9355bb3R125) [[3]](diffhunk://#diff-0dca34e50a1813e7353054cc6443b3851f9cdd060b828fd399676944b9355bb3R308-R315)

**Menu Item Styling Adjustments:**

- Removed hardcoded dividers from menu item styles in favor of the new `MenuDivider` component and improved icon alignment. [[1]](diffhunk://#diff-aaa3521c93d420c59de95ac3d116f50ec21a10ed8a0e3d51c62d2c2acae5e319L24) [[2]](diffhunk://#diff-aaa3521c93d420c59de95ac3d116f50ec21a10ed8a0e3d51c62d2c2acae5e319L34) [[3]](diffhunk://#diff-aaa3521c93d420c59de95ac3d116f50ec21a10ed8a0e3d51c62d2c2acae5e319L62-R60)

These changes collectively streamline the editor's interface, making menus more consistent and interactive, while providing users with more intuitive controls for managing fields and components.