### PR TITLE
Name clash fixes, fixed for module federation too

### DIFF
--- a/packages/editor/src/features/dashboard/Editor/PuckOverrides/Components/DrawerItem/index.tsx
+++ b/packages/editor/src/features/dashboard/Editor/PuckOverrides/Components/DrawerItem/index.tsx
@@ -5,17 +5,19 @@ import { getClassNameFactory } from '@helpers/styles/class-name-factory';
 import { useComponentSearchStore } from '..';
 import { useLocalStorage } from '@hooks/useLocalStorage';
 import { Tooltip } from '@components/Tooltip';
+import { COMPONENT_TYPE_DELIMITER } from '@helpers/editor/pageData/constants';
 const getClassName = getClassNameFactory('DrawerItem', styles);
 
 type DrawerItemProps = { name: string };
 
-export function DrawerItem({ name }: DrawerItemProps) {
+export function DrawerItem({ name: addonName }: DrawerItemProps) {
+  const name = addonName.split(COMPONENT_TYPE_DELIMITER)[0];
   const [proxiedComponents] = useLocalStorage<Record<string, string>>('proxied-components', {});
   const searchTerm = useComponentSearchStore(state => state.searchTerm);
   if (searchTerm && !name.toLowerCase().includes(searchTerm.toLowerCase())) return <></>; // Hide if not matching
   return (
     <Tooltip
-      title={proxiedComponents[name] ? `This component is proxied via module federation.` : undefined}
+      title={proxiedComponents[addonName] ? `This component is proxied via module federation.` : undefined}
       style={{
         width: '100%',
       }}
@@ -30,7 +32,7 @@ export function DrawerItem({ name }: DrawerItemProps) {
         justifyContent='start'
         className={getClassName({
           DrawerItem: true,
-          proxied: !!proxiedComponents[name],
+          proxied: !!proxiedComponents[addonName],
         })}
       >
         <div className={getClassName('DrawerItem-Icon')}>

--- a/packages/editor/src/helpers/editor/pageData/constants.ts
+++ b/packages/editor/src/helpers/editor/pageData/constants.ts
@@ -24,3 +24,5 @@ export const TEMPLATE_PREFIX = 'jinja2Template::';
 export const DEFAULT_FIELD_DEBOUNCE_MS = 150;
 
 export const CSS_VARIABLE_PREFIX = '--clr-';
+
+export const COMPONENT_TYPE_DELIMITER = '__@@__';


### PR DESCRIPTION
This pull request introduces a more robust approach to handling remote component identification and proxying in the editor, primarily by introducing a unique delimiter for component type names and updating how proxied components are tracked and displayed. It also adds user-facing error notifications for misconfigured or unavailable remote modules.

Key changes include:

**Component Identification and Proxying Improvements:**

* Introduced a new constant `COMPONENT_TYPE_DELIMITER` (`'__@@__'`) in `constants.ts` to uniquely identify remote components by combining their label and addon ID, preventing naming collisions.
* Updated the process of registering and referencing remote components in `PuckDynamicConfiguration/index.tsx` to use the new delimiter, ensuring that component keys and proxied component tracking are unique and consistent. [[1]](diffhunk://#diff-ac03997eb9ac4f034ecf54c1df78892a0f5b2844eb58a51f16584250db6c911fL248-R281) [[2]](diffhunk://#diff-ac03997eb9ac4f034ecf54c1df78892a0f5b2844eb58a51f16584250db6c911fL341-R364)

**User Experience Enhancements:**

* Added a plugin to display a toast error notification if a proxied remote component cannot be loaded due to module federation misconfiguration or the target remote not running, improving error visibility for users.

**Drawer Item Display Logic:**

* Modified `DrawerItem` to use the new component type naming convention and correctly display proxy status/tooltips based on the unique component identifier, ensuring accurate UI feedback. [[1]](diffhunk://#diff-3a49356e93e0c0ec28f31b9aa124fce3965a9e5b33f0c8ace3115d13c79880b1R8-R20) [[2]](diffhunk://#diff-3a49356e93e0c0ec28f31b9aa124fce3965a9e5b33f0c8ace3115d13c79880b1L33-R35)

**Supporting Imports:**

* Added necessary imports for the new delimiter constant and toast notifications in relevant files.