### PR TITLE
Adding CI script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun i
+
+      - name: Formatting check
+        run: bun run format:check
+
+      - name: Check theme generation
+        run: |
+          bun run generate-theme
+          if [ -n "$(git status --porcelain packages/editor/src/theme.css)" ]; then
+            echo "❌ Error: theme.css has uncommitted changes after running generate-theme"
+            echo "Please run 'bun run generate-theme' and commit the changes."
+            git diff packages/editor/src/theme.css
+            exit 1
+          fi
+          echo "✅ theme.css is up to date"
+
+      - name: Build and test
+        run: bun run build

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "prebuild": "bun run test && bun run type-check && bun run lint && bun run format",
     "build:editor": "NODE_ENV=production cd packages/editor && bun run build",
     "build:addon": "NODE_ENV=production cd packages/addon && bun run build",
-    "build": "bun run build:editor && bun run build:addon",
+    "build": "bun run generate-theme && bun run build:editor && bun run build:addon",
     "type-check:editor": "bun run --filter hakit-editor type-check",
     "type-check:addon": "bun run --filter @hakit/addon type-check",
     "type-check:server": "tsc -p packages/server/tsconfig.json --noEmit",


### PR DESCRIPTION
This pull request introduces a new CI workflow and improves the build process to ensure that the generated theme file is always up to date before building. The main changes are grouped below:

**Continuous Integration Setup:**

* Added a new GitHub Actions workflow in `.github/workflows/ci.yml` to automate checks on pull requests, including code checkout, Bun setup, dependency installation, formatting check, theme generation validation, and build steps.

**Build Process Improvements:**

* Updated the `build` script in `package.json` to run `generate-theme` before building the editor and addon packages, ensuring the theme file is generated and committed before builds.

**Theme File Consistency:**

* The CI workflow now checks for uncommitted changes in `packages/editor/src/theme.css` after running `generate-theme`, and fails the build if changes are detected, prompting the user to commit the updated theme file.